### PR TITLE
Fixes #9: deadlock issue

### DIFF
--- a/pkg/jar/jar.go
+++ b/pkg/jar/jar.go
@@ -66,6 +66,7 @@ func (j Jar) CheckFile(path string) ([]byte, error) {
 	}
 	filesMutex.Lock()
 	if _, exists := files[path]; exists {
+		filesMutex.Unlock()
 		return nil, nil
 	}
 	files[path] = true


### PR DESCRIPTION
On some occasions we run into a  `fatal error: all goroutines are asleep - deadlock!`  issue.
